### PR TITLE
fix: utilizando Scrypt da biblioteca bouncy castle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.bouncycastle</groupId>
+			<artifactId>bcprov-jdk18on</artifactId>
+			<version>1.82</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-docker-compose</artifactId>
 			<scope>runtime</scope>

--- a/src/main/java/br/mds/inti/config/SecurityConfig.java
+++ b/src/main/java/br/mds/inti/config/SecurityConfig.java
@@ -10,8 +10,9 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+//import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.crypto.scrypt.SCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -42,7 +43,8 @@ public class SecurityConfig {
 
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
+        return new SCryptPasswordEncoder(16384, 8, 1, 32, 16);
+        // return new BCryptPasswordEncoder();
     }
 
     @Bean


### PR DESCRIPTION
 Substituindo o `BCryptPasswordEncoder` pelo `SCryptPasswordEncoder` no bean `passwordEncoder()` 

**Mudanças incluídas:**
- Configuração do `SCryptPasswordEncoder` com parâmetros padroes.
  
- Adição da dependência do **Bouncy Castle** (`bcprov-jdk18on`), necessária para a implementação do scrypt.
 